### PR TITLE
Avoid a sprintf() warning in Perl 5.21

### DIFF
--- a/lib/Image/Size.pm
+++ b/lib/Image/Size.pm
@@ -325,7 +325,7 @@ sub html_imgsize
 
     # Use lowercase and quotes so that it works with xhtml.
     return ((defined $args[0]) ?
-            sprintf('width="%d" height="%d"', @args) :
+            sprintf('width="%d" height="%d"', @args[0,1]) :
             undef);
 }
 


### PR DESCRIPTION
Perl 5.21 introduces a warning for redundant arguments
to s?printf() -- so sprintf("%d", 1, 2) would warn.

This commit silences that warning by passing sprintf the
exact number of arguments that it expects.
