### PR TITLE
Replace "use vars" with "our"

### DIFF
--- a/imgsize
+++ b/imgsize
@@ -15,7 +15,7 @@
 
 use strict;
 use warnings;
-use vars qw($VERSION);
+our $VERSION;
 
 use File::Basename 'basename';
 use Getopt::Std;

--- a/lib/Image/Size.pm
+++ b/lib/Image/Size.pm
@@ -27,9 +27,9 @@ require 5.006001;
 use strict;
 use warnings;
 use bytes;
-use vars qw(
-    @EXPORT @EXPORT_OK %EXPORT_TAGS $VERSION $NO_CACHE %CACHE
-    $GIF_BEHAVIOR @TYPE_MAP %PCD_MAP $PCD_SCALE $READ_IN $LAST_POS
+our (
+    @EXPORT, @EXPORT_OK, %EXPORT_TAGS, $VERSION, $NO_CACHE, %CACHE,
+    $GIF_BEHAVIOR, @TYPE_MAP, %PCD_MAP, $PCD_SCALE, $READ_IN, $LAST_POS,
 );
 
 use Exporter 'import';

--- a/xt/00_load.t
+++ b/xt/00_load.t
@@ -1,7 +1,7 @@
 #!/usr/bin/perl
 
 use strict;
-use vars qw(@MODULES);
+our @MODULES;
 
 use Test::More;
 


### PR DESCRIPTION
Min version is set to Perl 5.6 which is just new enough to use "our".